### PR TITLE
Avoid panic when vault secret is empty

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pszmytka-viacom/vaultkv
+module github.com/postfinance/vaultkv
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/postfinance/vaultkv
+module github.com/pszmytka-viacom/vaultkv
 
 go 1.17
 

--- a/kv.go
+++ b/kv.go
@@ -68,6 +68,7 @@ func (c *Client) Read(p string) (map[string]interface{}, error) {
 		if s.Data["data"] == nil {
 			return nil, nil
 		}
+		
 		return s.Data["data"].(map[string]interface{}), nil
 	}
 

--- a/kv.go
+++ b/kv.go
@@ -65,6 +65,9 @@ func (c *Client) Read(p string) (map[string]interface{}, error) {
 	}
 
 	if c.Version == 2 {
+		if s.Data["data"] == nil {
+			return nil, nil
+		}
 		return s.Data["data"].(map[string]interface{}), nil
 	}
 


### PR DESCRIPTION
The panic occurs when:
- secrets are synchronized using [vault-kubernetes](https://github.com/postfinance/vault-kubernetes) is used to synchronize secrets 
- the secret was deleted (it is basically empty)

```
panic: interface conversion: interface {} is nil, not map[string]interface {}
goroutine 1 [running]:
github.com/postfinance/vaultkv.(*Client).Read(0xc0005e8fe0, 0xc00002c150, 0x69, 0x7, 0xc0003ccd88, 0x0)
  /home/runner/go/pkg/mod/github.com/postfinance/vaultkv@v0.0.3/kv.go:68 +0x1c6
main.(*syncConfig).synchronize(0xc00035faa0, 0x0, 0x0)
  /home/runner/work/vault-kubernetes/vault-kubernetes/cmd/synchronizer/main.go:184 +0x210
main.main()
  /home/runner/work/vault-kubernetes/vault-kubernetes/cmd/synchronizer/main.go:56 +0x1a9
```